### PR TITLE
test: add docker-compose for vyos

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,3 @@
+FROM ghcr.io/routedbits/vyos:1.4-rolling-202306080317
+
+COPY config.boot /opt/vyatta/etc/config/config.boot

--- a/config.boot
+++ b/config.boot
@@ -1,0 +1,56 @@
+interfaces {
+    ethernet eth0 {
+    }
+    loopback lo {
+    }
+}
+service {
+    ntp {
+        allow-client {
+            address 0.0.0.0/0
+            address ::/0
+        }
+        server time1.vyos.net {
+        }
+        server time2.vyos.net {
+        }
+        server time3.vyos.net {
+        }
+    }
+    ssh {
+    }
+}
+system {
+    config-management {
+        commit-revisions 100
+    }
+    console {
+        device ttyS0 {
+            speed 115200
+        }
+    }
+    host-name vyos
+    login {
+        user vyos {
+            authentication {
+                encrypted-password $6$QxPS.uk6mfo$9QBSo8u1FkH16gMyAVhus6fU3LOzvLR9Z9.82m3tiHFAxTtIkhaZSWssSgzt4v4dGAL8rhVQxTg0oAG9/q11h/
+                plaintext-password ""
+            }
+        }
+    }
+    syslog {
+        global {
+            facility all {
+                level info
+            }
+            facility local7 {
+                level debug
+            }
+        }
+    }
+}
+
+
+// Warning: Do not remove the following line.
+// vyos-config-version: "bgp@4:broadcast-relay@1:cluster@1:config-management@1:conntrack@3:conntrack-sync@2:container@1:dhcp-relay@2:dhcp-server@6:dhcpv6-server@1:dns-dynamic@1:dns-forwarding@4:firewall@10:flow-accounting@1:https@4:ids@1:interfaces@28:ipoe-server@1:ipsec@12:isis@3:l2tp@4:lldp@1:mdns@1:monitoring@1:nat@5:nat66@1:ntp@2:openconnect@2:ospf@2:policy@5:pppoe-server@6:pptp@2:qos@2:quagga@11:rip@1:rpki@1:salt@1:snmp@3:ssh@2:sstp@4:system@26:vrf@3:vrrp@3:vyos-accel-ppp@2:wanloadbalance@3:webproxy@2"
+// Release version: 1.4-rolling-202306080317

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,24 @@
+version: '2.4'
+
+services:
+  vyos:
+    build:
+      context: .
+    hostname: vyos
+    privileged: true
+    entrypoint: ['/sbin/init']
+    volumes:
+      - /lib/modules:/lib/modules
+    ports:
+      - 2222:22/tcp
+    networks:
+      - vyos
+    sysctls:
+      - net.ipv6.conf.all.disable_ipv6=0
+networks:
+  vyos:
+    enable_ipv6: true
+    ipam:
+      config:
+        - subnet: 192.0.2.0/24
+        - subnet: 2001:db8::/32


### PR DESCRIPTION
Just a basic docker-compose for a VyOS container, it only seems to really work on AMD64 and not ARM64 (even though the Mac can run it with emulation), the vyos user doesn't get created when it starts.

```
-> docker images
REPOSITORY                           TAG                        IMAGE ID       CREATED          SIZE
ghcr.io/routedbits/vyos                                 1.4-rolling-202306080317   4cb63a3fbbe9   23 minutes ago   1.25GB
```

What's interesting is that right from the start it has an IPv4/IPv6 address, even if it's not declared in the config. If you set an address on eth0 it will work, but those IPs remain. It might not be a big deal/matter in local dev/testing but if it conflicts with the templating then it might be annoying

```
vyos@vyos:~$ show interfaces 
Codes: S - State, L - Link, u - Up, D - Down, A - Admin Down
Interface        IP Address                        S/L  Description
---------        ----------                        ---  -----------
eth0             192.0.2.2/24                      u/u  
                 2001:db8::2/32                         
lo               127.0.0.1/8                       u/u  
                 ::1/128                                
```